### PR TITLE
Add plugin manifest and CI release pipeline

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -40,6 +40,7 @@ jobs:
         run: dotnet publish ShokoRelay/ShokoRelay.csproj -c Release -r ${{ matrix.rid }} --no-self-contained -o publish
         env:
           DOTNET_CLI_TELEMETRY_OPTOUT: '1'
+          RELEASE_CHANNEL: ${{ github.event.release.prerelease == true && 'Dev' || 'Stable' }}
 
       - name: Package ZIP (Linux)
         if: runner.os == 'Linux'
@@ -70,4 +71,64 @@ jobs:
           asset_content_type: application/zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  update-manifest:
+    name: Update plugin manifest
+    needs: [publish]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Update Manifest
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          VERSION="${TAG#v}"
+          SOURCE_REVISION=$(git rev-parse HEAD)
+          RELEASED_AT="${{ github.event.release.published_at }}"
+          CHANNEL="${{ github.event.release.prerelease == true && 'Dev' || 'Stable' }}"
+
+          # Download all release assets
+          gh release download "$TAG" \
+            --repo "${{ github.repository }}" \
+            --pattern "ShokoRelay-*.zip"
+
+          # Build archives JSON array
+          ARCHIVES_JSON="[]"
+          shopt -s nullglob
+          for ZIP in ShokoRelay-*.zip; do
+            RID="${ZIP#ShokoRelay-}"
+            RID="${RID%.zip}"
+            CHECKSUM=$(sha256sum "$ZIP" | awk '{ print $1 }')
+            URL="https://github.com/${{ github.repository }}/releases/download/${TAG}/${ZIP}"
+            ARCHIVE_ENTRY=$(jq -n \
+              --arg runtime "$RID" \
+              --arg abstraction "6.0.0" \
+              --arg url "$URL" \
+              --arg checksum "$CHECKSUM" \
+              '{runtime: $runtime, abstraction: $abstraction, url: $url, checksum: $checksum}')
+            ARCHIVES_JSON=$(echo "$ARCHIVES_JSON" | jq --argjson entry "$ARCHIVE_ENTRY" '. += [$entry]')
+          done
+
+          RELEASE_ENTRY=$(jq -n \
+            --arg version "$VERSION" \
+            --arg tag "$TAG" \
+            --arg source_revision "$SOURCE_REVISION" \
+            --arg released_at "$RELEASED_AT" \
+            --arg channel "$CHANNEL" \
+            --argjson archives "$ARCHIVES_JSON" \
+            '{version: $version, tag: $tag, source_revision: $source_revision, released_at: $released_at, channel: $channel, release_notes: null, archives: $archives}')
+
+          jq --argjson release "$RELEASE_ENTRY" '
+            .releases |= [ $release ] + (. | map(select(.version != $release.version)))
+          ' manifest.json > manifest.json.tmp && mv manifest.json.tmp manifest.json
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add manifest.json
+          git commit -m "ci: update manifest for ${TAG}"
+          git push origin HEAD:master
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <!-- prettier-ignore-start -->
 
-![Shoko Relay Logo](https://github.com/natyusha/ShokoRelay.bundle/assets/985941/23bfd7c2-eb89-46d5-a7cb-558c374393d6 "Shoko Relay")  
+![Shoko Relay Logo](https://github.com/natyusha/ShokoRelay.bundle/assets/985941/23bfd7c2-eb89-46d5-a7cb-558c374393d6 "Shoko Relay")
 [![Discord](https://img.shields.io/discord/96234011612958720?logo=discord&logoColor=fff&label=Discord&color=5865F2 "Shoko Discord")](https://discord.gg/shokoanime)
 [![Shoko Docs](https://img.shields.io/badge/VitePress-Shoko_Docs-4E7CF5?logo=vitepress&logoColor=fff)](https://docs.shokoanime.com/)
 [![GitHub Latest](https://img.shields.io/github/v/tag/natyusha/ShokoRelay?label=Latest&logo=github&logoColor=fff)](https://github.com/natyusha/ShokoRelay/releases/latest)
@@ -14,23 +14,24 @@ Due to the lack of a custom scanner this plugin leverages a VFS (Virtual File Sy
 
 ## Installation
 
-### Shoko
+### GUI (Recommended)
 
-> [!IMPORTANT]
-> The VFS is created inside each of Shoko's "destination" type folders under a subfolder named `!ShokoRelayVFS` (configurable under `Advanced Settings > VFS Root Path`). To stop Shoko from scanning the generated links, navigate to Shoko's installation directory and add the following regex entries to `settings-server.json` under `Exclude`:
->
-> ```json
-> "Exclude": [
->   "[\\\\\\/]!AnimeThemes[\\\\\\/]",
->   "[\\\\\\/]!ShokoRelayVFS[\\\\\\/]"
-> ],
-> ```
+1. Open the Shoko Web UI and navigate to **Settings → Plugins → Repositories**.
+2. Add the manifest URL:
+   ```
+   https://raw.githubusercontent.com/natyusha/ShokoRelay/master/manifest.json
+   ```
+3. Go to **Settings → Plugins → Browse** and find **Shoko Relay**.
+4. Click **Install** on the desired version.
+5. Restart Shoko.
 
-- Be sure to also exclude the `AnimeThemes Root Path` (default `!AnimeThemes`) if you plan on using AnimeThemes.
-- After excluding the VFS in Shoko's settings, extract [the latest release](https://github.com/natyusha/ShokoRelay/releases/latest) into Shoko Server's `plugins` directory
-- Restart Shoko Server
+### Manual
 
-#### Setup
+1. Download the latest `ShokoRelay-<rid>.zip` from the [Releases](../../releases) page.
+2. Extract the ZIP and place all the files into your Shoko **Plugins** folder.
+3. Restart Shoko.
+
+### Setup
 
 - Once the Server has loaded navigate to Shoko Relay's dashboard at the following URL:
   - `http(s)://{ShokoHost}:{ShokoPort}/api/plugin/ShokoRelay/dashboard`

--- a/ShokoRelay/ShokoRelay.cs
+++ b/ShokoRelay/ShokoRelay.cs
@@ -70,7 +70,7 @@ public class Plugin : IPlugin
     public string Name => ShokoRelayConstants.Name;
 
     /// <summary>Plugin description.</summary>
-    public string? Description => "A Custom Metadata Provider and Automation Tools for Plex and AnimeThemes in the form of a Shoko Server plugin";
+    public string? Description => "A Custom Metadata Provider and Automation Tools for Plex and AnimeThemes in the form of a Shoko Server plugin.";
 
     /// <summary>Plugin thumbnail resource.</summary>
     public string? EmbeddedThumbnailResourceName => "ShokoRelay.Assets.shoko-relay-thumbnail.png";

--- a/ShokoRelay/ShokoRelay.csproj
+++ b/ShokoRelay/ShokoRelay.csproj
@@ -3,6 +3,8 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <RepositoryUrl>https://github.com/natyusha/ShokoRelay</RepositoryUrl>
+    <PackageTags>hosted-service, vfs, plex, plex-metadata-provider, animethemes</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <CopyLocalLockFileAssemblies>false</CopyLocalLockFileAssemblies>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
@@ -36,4 +38,36 @@
       <Link>dashboard\%(RecursiveDir)%(Filename)%(Extension)</Link>
     </Content>
   </ItemGroup>
+
+  <Target Name="PluginAssemblyVersion" BeforeTargets="GetAssemblyVersion;GenerateAssemblyInfo" Condition="Exists('../.git')">
+    <PropertyGroup Condition="$(OS) == 'Windows_NT'">
+      <GitDateFormat>%%aI</GitDateFormat>
+      <NullStdErr>NUL</NullStdErr>
+    </PropertyGroup>
+    <PropertyGroup Condition="$(OS) != 'Windows_NT'">
+      <GitDateFormat>%aI</GitDateFormat>
+      <NullStdErr>/dev/null</NullStdErr>
+    </PropertyGroup>
+    <Exec Command="git log -1 --format=$(GitDateFormat)" ConsoleToMsBuild="true">
+      <Output TaskParameter="ConsoleOutput" PropertyName="_GitAuthorDateRaw" />
+    </Exec>
+    <Exec Command="git rev-parse HEAD" ConsoleToMsBuild="true">
+      <Output TaskParameter="ConsoleOutput" PropertyName="_GitCommitRaw" />
+    </Exec>
+    <Exec Command='git describe --exact-match --tags --match "v[0-9]*.[0-9]*.[0-9]*" 2>$(NullStdErr)' ConsoleToMsBuild="true" IgnoreExitCode="true">
+      <Output TaskParameter="ConsoleOutput" PropertyName="_GitTagRaw" />
+    </Exec>
+    <PropertyGroup>
+      <ReleaseDate>$([System.String]::Copy('$(_GitAuthorDateRaw)').Trim())</ReleaseDate>
+      <SourceRevision>$([System.String]::Copy('$(_GitCommitRaw)').Trim())</SourceRevision>
+      <ReleaseTag>$([System.String]::Copy('$(_GitTagRaw)').Trim())</ReleaseTag>
+    </PropertyGroup>
+    <ItemGroup>
+      <AssemblyMetadata Include="RuntimeIdentifier" Value="$(RuntimeIdentifier)" Condition="'$(RuntimeIdentifier)' != ''"/>
+      <AssemblyMetadata Include="ReleaseChannel" Value="$(RELEASE_CHANNEL)" Condition="'$(RELEASE_CHANNEL)' != ''"/>
+      <AssemblyMetadata Include="ReleaseDate" Value="$(ReleaseDate)" Condition="'$(ReleaseDate)' != ''"/>
+      <AssemblyMetadata Include="ReleaseTag" Value="$(ReleaseTag)" Condition="'$(ReleaseTag)' != ''"/>
+      <AssemblyMetadata Include="SourceRevision" Value="$(SourceRevision)" Condition="'$(SourceRevision)' != ''"/>
+    </ItemGroup>
+  </Target>
 </Project>

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,17 @@
+{
+  "id": "2b0f5a7e-3d2b-4f3d-9e6b-7f0a6b2d8c9a",
+  "name": "Shoko Relay",
+  "overview": "A Custom Metadata Provider and Automation Tools for Plex and AnimeThemes in the form of a Shoko Server plugin.",
+  "authors": "natyusha",
+  "repository_url": "https://github.com/natyusha/ShokoRelay",
+  "homepage_url": null,
+  "tags": [
+    "hosted-service",
+    "vfs",
+    "plex",
+    "plex-metadata-provider",
+    "animethemes"
+  ],
+  "thumbnail": "https://raw.githubusercontent.com/natyusha/ShokoRelay/master/ShokoRelay/Assets/shoko-relay-thumbnail.png",
+  "releases": []
+}


### PR DESCRIPTION
## Summary

Adds plugin manifest support and the CI automation to keep it in sync with releases, enabling installation via the Shoko Web UI plugin gallery.

## Changes

- **manifest.json** — New plugin manifest for the Shoko plugin gallery (empty releases, populated by CI)
- **ShokoRelay.csproj** — `PluginAssemblyVersion` target embeds `AssemblyMetadata` at build time:
  - `RuntimeIdentifier` (from `dotnet publish -r`)
  - `ReleaseChannel` (Stable/Dev based on prerelease flag)
  - `ReleaseDate` / `SourceRevision` / `ReleaseTag` (from git)
- **build-release.yml** — New `update-manifest` job (after all matrix builds):
  - Downloads all 3 platform zips from the release
  - Builds a manifest entry with all archives + checksums
  - Prepends to `manifest.json` releases and pushes to master
  - Also sets `RELEASE_CHANNEL` env var during build
- **README.md** — Installation instructions updated for GUI (manifest repo) and manual install methods