### PR TITLE
Remove scrollbar-gutter from html

### DIFF
--- a/ShokoRelay/Dashboard/css/style.css
+++ b/ShokoRelay/Dashboard/css/style.css
@@ -52,9 +52,6 @@
     transform: rotate(360deg);
   }
 }
-html {
-  scrollbar-gutter: stable;
-}
 body {
   margin: 11px;
   background: var(--bg-color);


### PR DESCRIPTION
<img width="943" height="424" alt="image" src="https://github.com/user-attachments/assets/eb2e912b-3f93-4395-8a5a-788536dcc374" />

That causes this extra gap in the webui while not really affecting much when opened directly in the browser so IMO, better to remove it